### PR TITLE
Bypass initial params to komposer on consecutive calls in Select Updatable

### DIFF
--- a/js/form/form-layouts/SelectUpdatable.vue
+++ b/js/form/form-layouts/SelectUpdatable.vue
@@ -49,9 +49,9 @@ export default {
             this.option = r.data.option //The user has to set a public option property on the Form
             this.optionValue = Object.keys(this.option)[0]
 
-            this.$_data({
-                ajaxPayload: {id: this.optionValue}
-            })
+          this.$_data({
+            ajaxPayload: Object.assign({id: this.optionValue}, this.$_data('ajaxPayload')),
+          })
                 
             var newSelect = this.komponents[0]
 


### PR DESCRIPTION
Currently when you pass additional parameters they properly passed in first  ajax call, but on first response ajaxPlayload property overrides which breaks consecutive calls to modal.
```
->addsRelatedOption(
                            PaymentMethodForm::class,
                            [
                                'providers' => ['sepa_debit'],
                                'intent' => 'payout'
                            ]
                        )
```

This pull request fixes the problem by merging existing ajaxPlayload back.