### PR TITLE
fix: inherited excess interactions from stripe card holder input

### DIFF
--- a/js/form/form-fields/Stripe.vue
+++ b/js/form/form-fields/Stripe.vue
@@ -115,7 +115,8 @@ export default {
             data: {
                 noLabel: true
             },
-            name: this.cardholderName
+            name: this.cardholderName,
+            interactions: [],
         })
 
     }


### PR DESCRIPTION
Currently when you assign onChange intecartion to stripe component it starts to be triggered by changing chardHolder element.
It happens because explicitly created component inherits interactions specified for entire stripe component, which shouldn't be the case.

