### PR TITLE
fix: allow to close edit modal with simple event

### DIFF
--- a/js/query/query-components/EditLinkModalContent.vue
+++ b/js/query/query-components/EditLinkModalContent.vue
@@ -25,8 +25,8 @@ export default {
         success(response, submitKomponent){
             this.$emit('refresh', this.index)
 
-            if(!this.keepModalOpen && !submitKomponent.$_keepModalOpen)
-                this.$emit('closeModal')
+            if (!this.keepModalOpen && (!submitKomponent || !submitKomponent.$_keepModalOpen))
+              this.$emit('closeModal')
         }
     }
 }


### PR DESCRIPTION
I found a use case were I just want to show a modal with some information, without any data to submit.

```
class DomainEmbedForm extends Form
{
    public function komponents()
    {
        return [
            _Title('Copy HTML to embed on your website'),
            _Textarea("fdafsfasfasf")->rows(10),
            _Button("Cancel")->outlined()->emit('success'),
        ];
    }
}
```
In DomainEmbedForm with success event I would like to close the modal, but it's impossible because EditLinkModalContent expects submit komponent object to be presented on success event. This pull request provides fix to mentioned issue, but probably it's not the cleanest solution for this problem.
